### PR TITLE
Set keyUse Parameter on RSAKey

### DIFF
--- a/app/src/main/kotlin/rocks/metaldetector/auth/config/AuthorizationServerConfig.kt
+++ b/app/src/main/kotlin/rocks/metaldetector/auth/config/AuthorizationServerConfig.kt
@@ -1,6 +1,7 @@
 package rocks.metaldetector.auth.config
 
 import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.KeyUse.SIGNATURE
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.jwk.source.JWKSource
 import com.nimbusds.jose.proc.SecurityContext
@@ -78,6 +79,7 @@ class AuthorizationServerConfig {
     return RSAKey.Builder(publicKey)
         .privateKey(privateKey)
         .keyID(KEY_ID)
+        .keyUse(SIGNATURE)
         .build()
   }
 
@@ -88,6 +90,7 @@ class AuthorizationServerConfig {
     return RSAKey.Builder(publicKey)
         .privateKey(privateKey)
         .keyID(KEY_ID)
+        .keyUse(SIGNATURE)
         .build()
   }
 


### PR DESCRIPTION
This is the [issue](https://bitbucket.org/connect2id/nimbus-jose-jwt/issues/461/revise-setting-of-key-use-in-jwkload) that was fixed in nimbus that creates our problems.
Maybe this will fix it...