### PR TITLE
Configure shutdown lifecycle

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     name: Metal Auth Service
   autoconfigure: # prevents spring from showing default user password in logs on startup
     exclude: org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+  lifecycle:
+    timeout-per-shutdown-phase: 60s
   datasource:
     username: ${DATASOURCE_USERNAME}
     password: ${DATASOURCE_PASSWORD}


### PR DESCRIPTION
As we have no async or scheduled tasks here I just set the shutdown timer for the app itself. Probably for this service it does not matter at all, but I like to have the configuration the same everywhere ;-)